### PR TITLE
Spelling fixes for Wishbringer (Solid Gold)

### DIFF
--- a/hints.zil
+++ b/hints.zil
@@ -763,7 +763,7 @@
 		 "Opening the metal can inside the Magick Shoppe?"
 		 "Examining the wanted posters in Festeron? In Witchville?"
 		 "Staying in the Jail Cell after being captured by the Boot Patrol?"
-		 "Getting captured three times by the Boot Patrol, after savingthe seahorse? Without saving the seahorse?"
+		 "Getting captured three times by the Boot Patrol, after saving the seahorse? Without saving the seahorse?"
 		 "Ignoring King Anatinus? Dropping the whistle or the hat?"
 		 "Letting the small mailbox meet the big mailbox?"
 		 "Looking around the Museum after the mailboxes have met? If the mailboxes never met?"


### PR DESCRIPTION
These are the spelling fixes for Wishbringer (Solid Gold) from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.

NB: This source code can't be the final Solid Gold version, since features are missing from it. Unfortunately, it's the last known preserved versions.